### PR TITLE
K2B-126 - Fix icon/point layers not rendering: newer style-spec adds …

### DIFF
--- a/src/util/web_worker_transfer.ts
+++ b/src/util/web_worker_transfer.ts
@@ -80,8 +80,13 @@ register('ResolvedImage', ResolvedImage);
 register('StylePropertyFunction', StylePropertyFunction);
 register('StyleExpression', StyleExpression, {omit: ['_evaluator']});
 
-register('ZoomDependentExpression', ZoomDependentExpression);
-register('ZoomConstantExpression', ZoomConstantExpression);
+// globalStateRefs is a Set added by newer @maplibre/maplibre-gl-style-spec
+// versions; this serializer has no Set support and nothing on the receiving
+// side reads it, so it must be omitted or worker transfer of any tile whose
+// buckets carry these expressions throws "can't serialize object of
+// unregistered class Set" and the tile never renders.
+register('ZoomDependentExpression', ZoomDependentExpression, {omit: ['globalStateRefs']});
+register('ZoomConstantExpression', ZoomConstantExpression, {omit: ['globalStateRefs']});
 register('CompoundExpression', CompoundExpression, {omit: ['_evaluate']});
 for (const name in expressions) {
     if ((expressions[name] as any)._classRegistryKey) continue;


### PR DESCRIPTION
…a globalStateRefs Set to expression classes which maplibre 5.0.1's worker serializer can't transfer, erroring every tile containing icon-styled layers; omit the field on ZoomConstant/ZoomDependentExpression registration.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
